### PR TITLE
cli updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Usage:
 
 Flags:
       --anonymize                    flag to anonymize collected NSX resources (default false)
+      --color                        flag to enable color output (default false)
   -e, --explain                      flag to explain connectivity output with rules explanations per allowed/denied connections (default false)
   -f, --filename string              file path to store analysis results
   -h, --help                         help for nsxanalyzer

--- a/README.md
+++ b/README.md
@@ -11,30 +11,30 @@ Run the `nsxanalyzer` CLI tool.
 
 ```
 $ ./bin/nsxanalyzer -h
-nsxanalyzer is a CLI for collecting NSX resources, analysis of permitted connectivity between VMs, and generation of k8s network policies.
-It uses REST API calls from NSX manager.
+nsxanalyzer is a CLI for collecting NSX resources, analysis of permitted connectivity between VMs,
+and generation of k8s network policies. It uses REST API calls from NSX manager.
 
 Usage:
   nsxanalyzer [flags]
 
 Flags:
-      --anonymize                    flag to anonymize collected nsx resources
-  -e, --explain                      connectivity output with rules explanations per allowed/denied connections
+      --anonymize                    flag to anonymize collected NSX resources (default false)
+  -e, --explain                      flag to explain connectivity output with rules explanations per allowed/denied connections (default false)
   -f, --filename string              file path to store analysis results
   -h, --help                         help for nsxanalyzer
-      --host string                  nsx host url
+      --host string                  NSX host URL. Alternatively, set the host via the NSX_HOST environment variable
   -o, --output string                output format; must be one of [txt, dot, json, svg] (default "txt")
       --output-filter strings        filter the analysis results by vm names, can specify more than one (example: "vm1,vm2")
-      --password string              nsx password
-  -q, --quiet                        runs quietly, reports only severe errors and results
+      --password string              NSX password. Alternatively, set the password via the NSX_PASSWORD environment variable
+  -q, --quiet                        flag to run quietly, report only severe errors and result (default false)
       --resource-dump-file string    file path to store collected resources in JSON format
   -r, --resource-input-file string   file path input JSON of NSX resources (instead of collecting from NSX host)
-      --skip-analysis                flag to skip analysis, run only collector and/or synthesis
+      --skip-analysis                flag to skip analysis, run only collector and/or synthesis (default false)
       --synthesis-dump-dir string    apply synthesis; specify directory path to store k8s synthesis results
-      --synthesize-admin-policies    include admin network policies in policy synthesis
+      --synthesize-admin-policies    include admin network policies in policy synthesis (default false)
       --topology-dump-file string    file path to store topology
-      --username string              nsx username
-  -v, --verbose                      runs with more informative messages printed to log
+      --username string              NSX username. Alternatively, set the username via the NSX_USER environment variable
+  -v, --verbose                      flag to run with more informative messages printed to log (default false)
       --version                      version for nsxanalyzer
 ```
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -41,6 +41,7 @@ const (
 	quietFlag                   = "quiet"
 	verboseFlag                 = "verbose"
 	explainFlag                 = "explain"
+	colorFlag                   = "color"
 
 	resourceInputFileHelp       = "file path input JSON of NSX resources (instead of collecting from NSX host)"
 	hostHelp                    = "NSX host URL. Alternatively, set the host via the NSX_HOST environment variable"
@@ -58,6 +59,7 @@ const (
 	outputFilterFlagHelp        = "filter the analysis results by vm names, can specify more than one (example: \"vm1,vm2\")"
 	quietHelp                   = "flag to run quietly, report only severe errors and result (default false)"
 	verboseHelp                 = "flag to run with more informative messages printed to log (default false)"
+	colorHelp                   = "flag to enable color output (default false)"
 )
 
 type inArgs struct {
@@ -77,6 +79,7 @@ type inArgs struct {
 	verbose           bool
 	explain           bool
 	outputFilter      []string
+	color             bool
 }
 
 func newRootCommand() *cobra.Command {
@@ -119,6 +122,7 @@ and generation of k8s network policies. It uses REST API calls from NSX manager.
 	rootCmd.PersistentFlags().BoolVarP(&args.quiet, quietFlag, "q", false, quietHelp)
 	rootCmd.PersistentFlags().BoolVarP(&args.verbose, verboseFlag, "v", false, verboseHelp)
 	rootCmd.PersistentFlags().BoolVarP(&args.explain, explainFlag, "e", false, explainHelp)
+	rootCmd.PersistentFlags().BoolVar(&args.color, colorFlag, false, colorHelp)
 	rootCmd.PersistentFlags().StringSliceVar(&args.outputFilter, outputFilterFlag, nil, outputFilterFlagHelp)
 
 	rootCmd.MarkFlagsMutuallyExclusive(resourceInputFileFlag, hostFlag)
@@ -195,6 +199,7 @@ func runCommand(args *inArgs) error {
 			FileName: args.outputFile,
 			VMs:      args.outputFilter,
 			Explain:  args.explain,
+			Color:    args.color,
 		}
 		logging.Infof("starting connectivity analysis")
 		connResStr, err := model.NSXConnectivityFromResourcesContainer(resources, params)

--- a/pkg/collector/nsx_conn.go
+++ b/pkg/collector/nsx_conn.go
@@ -1,0 +1,35 @@
+package collector
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/np-guard/vmware-analyzer/pkg/common"
+	"github.com/np-guard/vmware-analyzer/pkg/logging"
+)
+
+func getNSXArg(arg *string, envVar string) error {
+	if *arg != "" {
+		return nil
+	}
+	*arg = os.Getenv(envVar)
+	if *arg == "" {
+		return fmt.Errorf(common.ErrMissingRquiredArg+" %s", envVar)
+	}
+	return nil
+}
+
+func GetNSXServerDate(host, user, password string) (ServerData, error) {
+	// extract NSX credentials from cli args / env vars
+	if err := getNSXArg(&host, "NSX_HOST"); err != nil {
+		return ServerData{}, err
+	}
+	if err := getNSXArg(&user, "NSX_USER"); err != nil {
+		return ServerData{}, err
+	}
+	if err := getNSXArg(&password, "NSX_PASSWORD"); err != nil {
+		return ServerData{}, err
+	}
+	logging.Infof("collecting NSX resources from given host %s", host)
+	return NewServerData(host, user, password), nil
+}

--- a/pkg/collector/resources_container_model.go
+++ b/pkg/collector/resources_container_model.go
@@ -169,7 +169,7 @@ func (resources *ResourcesContainerModel) OutputTopologyGraph(fileName, format s
 	case common.JSONFormat:
 		g = common.NewTreeGraph()
 	case common.TextFormat:
-		g = common.NewEdgesGraph("topology", []string{})
+		g = common.NewEdgesGraph("topology", []string{}, false)
 	case common.DotFormat, common.SvgFormat:
 		g = common.NewDotGraph(true)
 	}

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,6 +1,7 @@
 package common
 
 const (
-	ErrNoResources string = "didn't get any collected resources"
-	ErrNoHostArg   string = "didn't get any host arg"
+	ErrNoResources       string = "didn't get any collected resources"
+	ErrNoHostArg         string = "didn't get any host arg"
+	ErrMissingRquiredArg string = "missing required arg"
 )

--- a/pkg/common/graphs.go
+++ b/pkg/common/graphs.go
@@ -87,10 +87,11 @@ type EdgesGraph struct {
 	edges                 []edge
 	header                string
 	tableHeaderComponents []string
+	color                 bool
 }
 
-func NewEdgesGraph(header string, tableHeaderComponents []string) *EdgesGraph {
-	return &EdgesGraph{header: header, tableHeaderComponents: tableHeaderComponents}
+func NewEdgesGraph(header string, tableHeaderComponents []string, color bool) *EdgesGraph {
+	return &EdgesGraph{header: header, tableHeaderComponents: tableHeaderComponents, color: color}
 }
 
 func (e *edge) tableStringComponents() []string {
@@ -126,7 +127,7 @@ func (eg *EdgesGraph) String() string {
 	for _, e := range eg.edges {
 		lines = append(lines, e.tableStringComponents())
 	}
-	return eg.header + NewLine + GenerateTableString(eg.tableHeaderComponents, lines, &TableOptions{SortLines: true})
+	return eg.header + NewLine + GenerateTableString(eg.tableHeaderComponents, lines, &TableOptions{SortLines: true, Colors: eg.color})
 }
 
 func (eg *EdgesGraph) JSONString() (string, error) {

--- a/pkg/common/output.go
+++ b/pkg/common/output.go
@@ -5,4 +5,5 @@ type OutputParameters struct {
 	FileName string
 	VMs      []string
 	Explain  bool
+	Color    bool
 }

--- a/pkg/common/strings.go
+++ b/pkg/common/strings.go
@@ -16,6 +16,8 @@ const (
 	NewLine             string = "\n"
 	Tab                 string = "\t"
 
+	AnalyzedConnectivityHeader = "Analyzed connectivity:"
+
 	// ANSI escape codes - for colored output printed to the terminal
 	reset   = "\033[0m"
 	red     = "\033[31m"

--- a/pkg/model/analyzer.go
+++ b/pkg/model/analyzer.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NSXConnectivityFromResourcesContainer(recourses *collector.ResourcesContainerModel, params common.OutputParameters) (string, error) {
-	config, err := configFromResourcesContainer(recourses, params.VMs)
+	config, err := configFromResourcesContainer(recourses, params)
 	if err != nil {
 		return "", err
 	}
@@ -42,7 +42,7 @@ func NSXConnectivityFromResourcesContainerPlainText(recourses *collector.Resourc
 	return NSXConnectivityFromResourcesContainer(recourses, common.OutputParameters{Format: common.TextFormat})
 }
 
-func configFromResourcesContainer(recourses *collector.ResourcesContainerModel, vmsFilter []string) (*config, error) {
+func configFromResourcesContainer(recourses *collector.ResourcesContainerModel, params common.OutputParameters) (*config, error) {
 	parser := NewNSXConfigParserFromResourcesContainer(recourses)
 	err := parser.RunParser()
 	if err != nil {
@@ -51,10 +51,10 @@ func configFromResourcesContainer(recourses *collector.ResourcesContainerModel, 
 	config := parser.GetConfig()
 
 	// in debug/verbose mode -- print the parsed config
-	logging.Debugf("the parsed config details: %s", config.getConfigInfoStr())
+	logging.Debugf("the parsed config details: %s", config.getConfigInfoStr(params.Color))
 
 	// compute connectivity map from the parsed config
-	config.ComputeConnectivity(vmsFilter)
+	config.ComputeConnectivity(params.VMs)
 
 	return config, nil
 }

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -41,20 +41,20 @@ func (c *config) ComputeConnectivity(vmsFilter []string) {
 }
 
 // getConfigInfoStr returns string describing the captured configuration content
-func (c *config) getConfigInfoStr() string {
+func (c *config) getConfigInfoStr(color bool) string {
 	var sb strings.Builder
 	sb.WriteString(common.OutputSectionSep)
 	sb.WriteString("VMs:\n")
-	sb.WriteString(c.getVMsInfoStr())
+	sb.WriteString(c.getVMsInfoStr(color))
 
 	// groups
 	sb.WriteString(common.OutputSectionSep)
 	sb.WriteString("Groups:\n")
-	sb.WriteString(c.getVMGroupsStr())
+	sb.WriteString(c.getVMGroupsStr(color))
 	sb.WriteString(common.OutputSectionSep)
 
 	sb.WriteString("DFW:\n")
-	sb.WriteString(c.Fw.OriginalRulesStrFormatted())
+	sb.WriteString(c.Fw.OriginalRulesStrFormatted(color))
 	sb.WriteString(common.ShortSep)
 	sb.WriteString(c.Fw.String())
 	sb.WriteString(common.ShortSep)
@@ -64,21 +64,21 @@ func (c *config) getConfigInfoStr() string {
 	return sb.String()
 }
 
-func (c *config) getVMGroupsStr() string {
+func (c *config) getVMGroupsStr(color bool) string {
 	header := []string{"VM", "Groups"}
 	lines := [][]string{}
 	for vm, groups := range c.GroupsPerVM {
 		groupsStr := common.JoinCustomStrFuncSlice(groups, func(g *collector.Group) string { return *g.DisplayName }, common.CommaSpaceSeparator)
 		lines = append(lines, []string{vm.Name(), groupsStr})
 	}
-	return common.GenerateTableString(header, lines, &common.TableOptions{SortLines: true})
+	return common.GenerateTableString(header, lines, &common.TableOptions{SortLines: true, Colors: color})
 }
 
-func (c *config) getVMsInfoStr() string {
+func (c *config) getVMsInfoStr(color bool) string {
 	header := []string{"VM Name", "VM ID", "VM Addresses"}
 	lines := [][]string{}
 	for _, vm := range c.vms {
 		lines = append(lines, []string{vm.Name(), vm.ID(), strings.Join(vm.IPAddresses(), common.CommaSeparator)})
 	}
-	return common.GenerateTableString(header, lines, &common.TableOptions{SortLines: true})
+	return common.GenerateTableString(header, lines, &common.TableOptions{SortLines: true, Colors: color})
 }

--- a/pkg/model/connectivity/output.go
+++ b/pkg/model/connectivity/output.go
@@ -13,7 +13,7 @@ func (c ConnMap) GenConnectivityOutput(params common.OutputParameters) (res stri
 	case common.JSONFormat:
 		g = common.NewEdgesGraph("", []string{})
 	case common.TextFormat:
-		g = common.NewEdgesGraph("Analyzed connectivity:", []string{"Source", "Destination", "Permitted connections"})
+		g = common.NewEdgesGraph(common.AnalyzedConnectivityHeader, []string{"Source", "Destination", "Permitted connections"})
 	case common.DotFormat, common.SvgFormat:
 		g = common.NewDotGraph(false)
 	}

--- a/pkg/model/connectivity/output.go
+++ b/pkg/model/connectivity/output.go
@@ -11,9 +11,9 @@ func (c ConnMap) GenConnectivityOutput(params common.OutputParameters) (res stri
 	var g common.Graph
 	switch params.Format {
 	case common.JSONFormat:
-		g = common.NewEdgesGraph("", []string{})
+		g = common.NewEdgesGraph("", []string{}, false)
 	case common.TextFormat:
-		g = common.NewEdgesGraph(common.AnalyzedConnectivityHeader, []string{"Source", "Destination", "Permitted connections"})
+		g = common.NewEdgesGraph(common.AnalyzedConnectivityHeader, []string{"Source", "Destination", "Permitted connections"}, params.Color)
 	case common.DotFormat, common.SvgFormat:
 		g = common.NewDotGraph(false)
 	}

--- a/pkg/model/dfw/dfw.go
+++ b/pkg/model/dfw/dfw.go
@@ -153,13 +153,13 @@ func (d *DFW) AllowedConnectionsIngressOrEgress(src, dst *endpoints.VM, isIngres
 	return allAllowedConns, allDeniedConns, delegatedConns
 }
 
-func (d *DFW) OriginalRulesStrFormatted() string {
+func (d *DFW) OriginalRulesStrFormatted(color bool) string {
 	header := getRulesHeader()
 	lines := [][]string{}
 	for _, c := range d.CategoriesSpecs {
 		lines = append(lines, c.originalRulesComponentsStr()...)
 	}
-	return "original rules:\n" + common.GenerateTableString(header, lines, &common.TableOptions{Colors: true})
+	return "original rules:\n" + common.GenerateTableString(header, lines, &common.TableOptions{Colors: color})
 }
 
 // return a string rep that shows the fw-rules in all categories

--- a/pkg/model/explanation_test.go
+++ b/pkg/model/explanation_test.go
@@ -503,7 +503,7 @@ func (r *rulesTest) runTest(t *testing.T) {
 	require.Nil(t, err)
 	fmt.Println(connResStr)
 
-	configWithAnalysis, err := configFromResourcesContainer(rc, nil)
+	configWithAnalysis, err := configFromResourcesContainer(rc, common.OutputParameters{})
 	require.Nil(t, err)
 
 	// test explanations by comparison to expectedExplanation objects

--- a/pkg/model/verify_trace_flow.go
+++ b/pkg/model/verify_trace_flow.go
@@ -16,7 +16,7 @@ func compareConfigToTraceflows(
 	resources *collector.ResourcesContainerModel,
 	server collector.ServerData,
 	vmFilter vmFilter) (*collector.TraceFlows, error) {
-	config, err := configFromResourcesContainer(resources, nil)
+	config, err := configFromResourcesContainer(resources, common.OutputParameters{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/verify_trace_flow_test.go
+++ b/pkg/model/verify_trace_flow_test.go
@@ -2,13 +2,13 @@ package model
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/np-guard/vmware-analyzer/pkg/collector"
 	"github.com/np-guard/vmware-analyzer/pkg/common"
+	"github.com/np-guard/vmware-analyzer/pkg/logging"
 	"github.com/np-guard/vmware-analyzer/pkg/model/endpoints"
 )
 
@@ -28,23 +28,19 @@ func Test_verifyTraceflow(t *testing.T) {
 		{
 			"simple",
 			args{
-				// you can set your server info here:
-				"no_server",
-				"no_user",
-				"no_password",
+				// you can set your server info here
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args.nsxServer == "no_server" {
-				if os.Getenv("NSX_HOST") == "" {
-					fmt.Println(common.ErrNoHostArg)
-					return
-				}
-				tt.args = args{os.Getenv("NSX_HOST"), os.Getenv("NSX_USER"), os.Getenv("NSX_PASSWORD")}
+			logging.Init(logging.HighVerbosity)
+			server, err := collector.GetNSXServerDate(tt.args.nsxServer, tt.args.userName, tt.args.password)
+			if err != nil {
+				// do not fail on env without access to nsx host
+				fmt.Println(err.Error())
+				return
 			}
-			server := collector.NewServerData(tt.args.nsxServer, tt.args.userName, tt.args.password)
 			collectedResources, err := collector.CollectResources(server)
 			if err != nil {
 				t.Errorf("CollectResources() error = %v", err)

--- a/pkg/synthesis/synthesis_test.go
+++ b/pkg/synthesis/synthesis_test.go
@@ -256,9 +256,10 @@ func addDebugFiles(t *testing.T, rc *collector.ResourcesContainerModel, abstract
 // (2) equiv config in NSX with allow-only DFW rules, as derived from the abstract model
 // and validates that connectivity of orign and new NSX configs are the same
 func TestCollectAndConvertToAbstract(t *testing.T) {
-	server := collector.NewServerData(os.Getenv("NSX_HOST"), os.Getenv("NSX_USER"), os.Getenv("NSX_PASSWORD"))
-	if (server == collector.ServerData{}) {
-		fmt.Println(common.ErrNoHostArg)
+	logging.Init(logging.HighVerbosity)
+	server, err := collector.GetNSXServerDate("", "", "")
+	if err != nil {
+		fmt.Println(err.Error())
 		return
 	}
 


### PR DESCRIPTION
- CLI command help improvements (#151)
- support env vars (NSX_HOST etc) from CLI, unified handling for both tests and cli 
- improve unit tests for `main_test` , validate output files are created, errors validation
- add cli flag for colored output (analysis output and its verbose log of nsx config captured) 