### PR TITLE
convert connections to nsx services entries 

### DIFF
--- a/pkg/collector/data/examples_generator.go
+++ b/pkg/collector/data/examples_generator.go
@@ -332,32 +332,29 @@ func serviceEntries(services []string, conn *netset.TransportSet) ([]string, col
 			entries = append(entries, entry)
 		}
 	}
-	icmpSet := conn.ICMPSet()
-	if !icmpSet.IsEmpty() {
-		for _, partition := range icmpSet.Partitions() {
-			types := []*int{nil}
-			codes := []*int{nil}
-			typesSet := partition.Left
-			codesSet := partition.Right
-			if !typesSet.Equal(netset.AllICMPTypes()) {
-				types = make([]*int, len(typesSet.Elements()))
-				for i, typeNumber := range typesSet.Elements() {
-					types[i] = common.PointerTo(int(typeNumber))
-				}
+	for _, partition := range conn.ICMPSet().Partitions() {
+		types := []*int{nil}
+		codes := []*int{nil}
+		typesSet := partition.Left
+		codesSet := partition.Right
+		if !typesSet.Equal(netset.AllICMPTypes()) {
+			types = make([]*int, len(typesSet.Elements()))
+			for i, typeNumber := range typesSet.Elements() {
+				types[i] = common.PointerTo(int(typeNumber))
 			}
-			if !codesSet.Equal(netset.AllICMPCodes()) {
-				codes = make([]*int, len(codesSet.Elements()))
-				for i, code := range codesSet.Elements() {
-					codes[i] = common.PointerTo(int(code))
-				}
+		}
+		if !codesSet.Equal(netset.AllICMPCodes()) {
+			codes = make([]*int, len(codesSet.Elements()))
+			for i, code := range codesSet.Elements() {
+				codes[i] = common.PointerTo(int(code))
 			}
-			for _, t := range types {
-				for _, c := range codes {
-					entry := &collector.ICMPTypeServiceEntry{}
-					entry.IcmpCode = c
-					entry.IcmpType = t
-					entries = append(entries, entry)
-				}
+		}
+		for _, t := range types {
+			for _, c := range codes {
+				entry := &collector.ICMPTypeServiceEntry{}
+				entry.IcmpCode = c
+				entry.IcmpType = t
+				entries = append(entries, entry)
 			}
 		}
 	}

--- a/pkg/collector/data/examples_generator.go
+++ b/pkg/collector/data/examples_generator.go
@@ -306,9 +306,6 @@ var codeToProtocol = map[int]nsx.L4PortSetServiceEntryL4Protocol{
 	netset.TCPCode: nsx.L4PortSetServiceEntryL4ProtocolTCP,
 }
 
-func pointerTo[T any](t T) *T {
-	return &t
-}
 func serviceEntries(services []string, conn *netset.TransportSet) ([]string, collector.ServiceEntries) {
 	if conn == nil {
 		return services, nil
@@ -322,7 +319,7 @@ func serviceEntries(services []string, conn *netset.TransportSet) ([]string, col
 		portRanges := partition.S3.Intervals()
 		for _, protocolCode := range protocolsCodes {
 			entry := &collector.L4PortSetServiceEntry{}
-			entry.L4Protocol = pointerTo(codeToProtocol[int(protocolCode)])
+			entry.L4Protocol = common.PointerTo(codeToProtocol[int(protocolCode)])
 			for _, portRange := range portRanges {
 				var ports nsx.PortElement
 				if portRange.Start() == portRange.End() {
@@ -345,13 +342,13 @@ func serviceEntries(services []string, conn *netset.TransportSet) ([]string, col
 			if !typesSet.Equal(netset.AllICMPTypes()) {
 				types = make([]*int, len(typesSet.Elements()))
 				for i, typeNumber := range typesSet.Elements() {
-					types[i] = pointerTo(int(typeNumber))
+					types[i] = common.PointerTo(int(typeNumber))
 				}
 			}
 			if !codesSet.Equal(netset.AllICMPCodes()) {
 				codes = make([]*int, len(codesSet.Elements()))
 				for i, code := range codesSet.Elements() {
-					codes[i] = pointerTo(int(code))
+					codes[i] = common.PointerTo(int(code))
 				}
 			}
 			for _, t := range types {

--- a/pkg/collector/data/examples_generator.go
+++ b/pkg/collector/data/examples_generator.go
@@ -341,7 +341,7 @@ func serviceEntries(services []string, conn *netset.TransportSet) ([]string, col
 		entry := &collector.ICMPTypeServiceEntry{}
 		entries = append(entries, entry)
 	}
-	return nil, entries
+	return services, entries
 }
 
 /*

--- a/pkg/collector/data_model.go
+++ b/pkg/collector/data_model.go
@@ -94,11 +94,15 @@ func (rule *RedirectionRule) UnmarshalJSON(b []byte) error {
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////
-type IPProtocolServiceEntry struct {
-	nsx.IPProtocolServiceEntry
+func pointerTo[T any](t T) *T {
+	return &t
 }
 
 const creatingConnectionError = "fail to create a connection from service %v"
+
+type IPProtocolServiceEntry struct {
+	nsx.IPProtocolServiceEntry
+}
 
 func (e *IPProtocolServiceEntry) String() string {
 	return serviceEntryStr(nsx.IPProtocolServiceEntryResourceTypeIPProtocolServiceEntry, *e.DisplayName)
@@ -241,6 +245,31 @@ type ServiceEntry interface {
 }
 
 type ServiceEntries []ServiceEntry
+
+func (s *ServiceEntries) MarshalJSON() ([]byte, error) {
+	type ServiceEntries_plain ServiceEntries
+	for _, e := range *s {
+
+		switch v := e.(type) {
+		case *ALGTypeServiceEntry:
+			v.ResourceType = pointerTo(nsx.ALGTypeServiceEntryResourceTypeALGTypeServiceEntry)
+		case *EtherTypeServiceEntry:
+			v.ResourceType = pointerTo(nsx.EtherTypeServiceEntryResourceTypeEtherTypeServiceEntry)
+		case *ICMPTypeServiceEntry:
+			v.ResourceType = pointerTo(nsx.ICMPTypeServiceEntryResourceTypeICMPTypeServiceEntry)
+		case *IGMPTypeServiceEntry:
+			v.ResourceType = pointerTo(nsx.IGMPTypeServiceEntryResourceTypeIGMPTypeServiceEntry)
+		case *IPProtocolServiceEntry:
+			v.ResourceType = pointerTo(nsx.IPProtocolServiceEntryResourceTypeIPProtocolServiceEntry)
+		case *L4PortSetServiceEntry:
+			v.ResourceType = pointerTo(nsx.L4PortSetServiceEntryResourceTypeL4PortSetServiceEntry)
+		case *NestedServiceServiceEntry:
+			v.ResourceType = pointerTo(nsx.NestedServiceServiceEntryResourceTypeNestedServiceServiceEntry)
+		}
+	}
+	sp := ServiceEntries_plain(*s)
+	return json.Marshal(sp)
+}
 
 func (s *ServiceEntries) UnmarshalJSON(b []byte) error {
 	var raws []json.RawMessage

--- a/pkg/collector/data_model.go
+++ b/pkg/collector/data_model.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/np-guard/models/pkg/netp"
 	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/vmware-analyzer/pkg/common"
 	nsx "github.com/np-guard/vmware-analyzer/pkg/model/generated"
 )
 
@@ -94,12 +95,6 @@ func (rule *RedirectionRule) UnmarshalJSON(b []byte) error {
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////
-func pointerTo[T any](t T) *T {
-	return &t
-}
-
-const creatingConnectionError = "fail to create a connection from service %v"
-
 type IPProtocolServiceEntry struct {
 	nsx.IPProtocolServiceEntry
 }
@@ -109,7 +104,7 @@ func (e *IPProtocolServiceEntry) String() string {
 }
 
 func (e *IPProtocolServiceEntry) ToConnection() (*netset.TransportSet, error) {
-	return nil, fmt.Errorf(creatingConnectionError, *e.ResourceType)
+	return nil, fmt.Errorf(common.ErrCreatingConnection, *e.ResourceType)
 }
 
 type IGMPTypeServiceEntry struct {
@@ -121,7 +116,7 @@ func (e *IGMPTypeServiceEntry) String() string {
 }
 
 func (e *IGMPTypeServiceEntry) ToConnection() (*netset.TransportSet, error) {
-	return nil, fmt.Errorf(creatingConnectionError, *e.ResourceType)
+	return nil, fmt.Errorf(common.ErrCreatingConnection, *e.ResourceType)
 }
 
 type ICMPTypeServiceEntry struct {
@@ -158,7 +153,7 @@ func (e *ALGTypeServiceEntry) String() string {
 }
 
 func (e *ALGTypeServiceEntry) ToConnection() (*netset.TransportSet, error) {
-	return nil, fmt.Errorf(creatingConnectionError, *e.ResourceType)
+	return nil, fmt.Errorf(common.ErrCreatingConnection, *e.ResourceType)
 }
 
 type L4PortSetServiceEntry struct {
@@ -224,7 +219,7 @@ func (e *EtherTypeServiceEntry) String() string {
 }
 
 func (e *EtherTypeServiceEntry) ToConnection() (*netset.TransportSet, error) {
-	return nil, fmt.Errorf(creatingConnectionError, *e.ResourceType)
+	return nil, fmt.Errorf(common.ErrCreatingConnection, *e.ResourceType)
 }
 
 type NestedServiceServiceEntry struct {
@@ -236,7 +231,7 @@ func (e *NestedServiceServiceEntry) String() string {
 }
 
 func (e *NestedServiceServiceEntry) ToConnection() (*netset.TransportSet, error) {
-	return nil, fmt.Errorf(creatingConnectionError, *e.ResourceType)
+	return nil, fmt.Errorf(common.ErrCreatingConnection, *e.ResourceType)
 }
 
 type ServiceEntry interface {
@@ -252,19 +247,19 @@ func (s *ServiceEntries) MarshalJSON() ([]byte, error) {
 
 		switch v := e.(type) {
 		case *ALGTypeServiceEntry:
-			v.ResourceType = pointerTo(nsx.ALGTypeServiceEntryResourceTypeALGTypeServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.ALGTypeServiceEntryResourceTypeALGTypeServiceEntry)
 		case *EtherTypeServiceEntry:
-			v.ResourceType = pointerTo(nsx.EtherTypeServiceEntryResourceTypeEtherTypeServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.EtherTypeServiceEntryResourceTypeEtherTypeServiceEntry)
 		case *ICMPTypeServiceEntry:
-			v.ResourceType = pointerTo(nsx.ICMPTypeServiceEntryResourceTypeICMPTypeServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.ICMPTypeServiceEntryResourceTypeICMPTypeServiceEntry)
 		case *IGMPTypeServiceEntry:
-			v.ResourceType = pointerTo(nsx.IGMPTypeServiceEntryResourceTypeIGMPTypeServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.IGMPTypeServiceEntryResourceTypeIGMPTypeServiceEntry)
 		case *IPProtocolServiceEntry:
-			v.ResourceType = pointerTo(nsx.IPProtocolServiceEntryResourceTypeIPProtocolServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.IPProtocolServiceEntryResourceTypeIPProtocolServiceEntry)
 		case *L4PortSetServiceEntry:
-			v.ResourceType = pointerTo(nsx.L4PortSetServiceEntryResourceTypeL4PortSetServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.L4PortSetServiceEntryResourceTypeL4PortSetServiceEntry)
 		case *NestedServiceServiceEntry:
-			v.ResourceType = pointerTo(nsx.NestedServiceServiceEntryResourceTypeNestedServiceServiceEntry)
+			v.ResourceType = common.PointerTo(nsx.NestedServiceServiceEntryResourceTypeNestedServiceServiceEntry)
 		}
 	}
 	sp := ServiceEntries_plain(*s)

--- a/pkg/collector/data_model.go
+++ b/pkg/collector/data_model.go
@@ -242,9 +242,8 @@ type ServiceEntry interface {
 type ServiceEntries []ServiceEntry
 
 func (s *ServiceEntries) MarshalJSON() ([]byte, error) {
-	type ServiceEntries_plain ServiceEntries
+	type ServiceEntriesPlain ServiceEntries
 	for _, e := range *s {
-
 		switch v := e.(type) {
 		case *ALGTypeServiceEntry:
 			v.ResourceType = common.PointerTo(nsx.ALGTypeServiceEntryResourceTypeALGTypeServiceEntry)
@@ -262,7 +261,7 @@ func (s *ServiceEntries) MarshalJSON() ([]byte, error) {
 			v.ResourceType = common.PointerTo(nsx.NestedServiceServiceEntryResourceTypeNestedServiceServiceEntry)
 		}
 	}
-	sp := ServiceEntries_plain(*s)
+	sp := ServiceEntriesPlain(*s)
 	return json.Marshal(sp)
 }
 

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,6 +1,7 @@
 package common
 
 const (
-	ErrNoResources string = "didn't get any collected resources"
-	ErrNoHostArg   string = "didn't get any host arg"
+	ErrNoResources        string = "didn't get any collected resources"
+	ErrNoHostArg          string = "didn't get any host arg"
+	ErrCreatingConnection string = "fail to create a connection from service %v"
 )

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,8 +1,8 @@
 package common
 
 const (
-	ErrNoResources       string = "didn't get any collected resources"
-	ErrNoHostArg         string = "didn't get any host arg"
-	ErrMissingRquiredArg string = "missing required arg"
+	ErrNoResources        string = "didn't get any collected resources"
+	ErrNoHostArg          string = "didn't get any host arg"
+	ErrMissingRquiredArg  string = "missing required arg"
 	ErrCreatingConnection string = "fail to create a connection from service %v"
 )

--- a/pkg/common/system.go
+++ b/pkg/common/system.go
@@ -54,3 +54,8 @@ func marshalYamlUsingJSON(content interface{}) ([]byte, error) {
 	}
 	return yaml.Marshal(contentFromJSON)
 }
+
+func PointerTo[T any](t T) *T {
+	return &t
+}
+

--- a/pkg/common/system.go
+++ b/pkg/common/system.go
@@ -58,4 +58,3 @@ func marshalYamlUsingJSON(content interface{}) ([]byte, error) {
 func PointerTo[T any](t T) *T {
 	return &t
 }
-

--- a/pkg/synthesis/createNSXPolicies.go
+++ b/pkg/synthesis/createNSXPolicies.go
@@ -84,7 +84,10 @@ func (a *absToNXS) convertPolicies(policy []*symbolicPolicy) {
 			}
 		}
 	}
-	// add default deny rule
+	a.addDefaultDenyRule()
+}
+
+func (a *absToNXS) addDefaultDenyRule() {
 	const defaultDenyID = 9999
 	r := a.addNewRule(collector.AppCategoty.String())
 	r.Action = data.Drop
@@ -97,21 +100,13 @@ func (a *absToNXS) convertPolicies(policy []*symbolicPolicy) {
 }
 
 func (a *absToNXS) pathToRule(p *symbolicexpr.SymbolicPath, direction, action, categoryType string) {
-	srcGroup, dstGroup, services := a.toGroupsAndService(p)
 	rule := a.addNewRule(categoryType)
 	rule.Action = action
 	rule.Description = action + ": " + p.String()
-	rule.Source = srcGroup
-	rule.Dest = dstGroup
-	rule.Services = services
+	rule.Source = a.createGroup(p.Src)
+	rule.Dest = a.createGroup(p.Dst)
+	rule.Conn = p.Conn
 	rule.Direction = direction
-}
-
-func (a *absToNXS) toGroupsAndService(p *symbolicexpr.SymbolicPath) (src, dst string, service []string) {
-	srcVMs := a.createGroup(p.Src)
-	dstVMs := a.createGroup(p.Dst)
-	services := []string{data.AnyStr} // todo
-	return srcVMs, dstVMs, services
 }
 
 func (a *absToNXS) addNewRule(categoryType string) *data.Rule {

--- a/pkg/synthesis/k8sPolicies.go
+++ b/pkg/synthesis/k8sPolicies.go
@@ -7,6 +7,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admin "sigs.k8s.io/network-policy-api/apis/v1alpha1"
 
+	"github.com/np-guard/vmware-analyzer/pkg/common"
 	"github.com/np-guard/vmware-analyzer/pkg/logging"
 	"github.com/np-guard/vmware-analyzer/pkg/model/dfw"
 	"github.com/np-guard/vmware-analyzer/pkg/symbolicexpr"
@@ -98,12 +99,12 @@ func (policies *k8sPolicies) addAdminNetworkPolicy(srcSelector, dstSelector *met
 	dstPodsSelector := &admin.NamespacedPod{PodSelector: *dstSelector}
 	if inbound {
 		from := []admin.AdminNetworkPolicyIngressPeer{{Pods: srcPodsSelector}}
-		rules := []admin.AdminNetworkPolicyIngressRule{{From: from, Action: action, Ports: pointerTo(ports)}}
+		rules := []admin.AdminNetworkPolicyIngressRule{{From: from, Action: action, Ports: common.PointerTo(ports)}}
 		pol.Spec.Ingress = rules
 		pol.Spec.Subject = admin.AdminNetworkPolicySubject{Pods: dstPodsSelector}
 	} else {
 		to := []admin.AdminNetworkPolicyEgressPeer{{Pods: dstPodsSelector}}
-		rules := []admin.AdminNetworkPolicyEgressRule{{To: to, Action: action, Ports: pointerTo(ports)}}
+		rules := []admin.AdminNetworkPolicyEgressRule{{To: to, Action: action, Ports: common.PointerTo(ports)}}
 		pol.Spec.Egress = rules
 		pol.Spec.Subject = admin.AdminNetworkPolicySubject{Pods: srcPodsSelector}
 	}

--- a/pkg/synthesis/k8sPorts.go
+++ b/pkg/synthesis/k8sPorts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/np-guard/models/pkg/netp"
 	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/vmware-analyzer/pkg/common"
 )
 
 func connToPolicyPort(conn *netset.TransportSet) []networking.NetworkPolicyPort {
@@ -62,10 +63,6 @@ func connToPorts(ports k8sPorts, conn *netset.TransportSet) {
 	}
 }
 
-func pointerTo[T any](t T) *T {
-	return &t
-}
-
 // ////////////////////////////////////////////////////
 type k8sNetworkPorts struct {
 	ports []networking.NetworkPolicyPort
@@ -84,7 +81,7 @@ func (ports *k8sNetworkPorts) addPorts(start, end int64, protocols []core.Protoc
 	}
 	for _, protocol := range protocols {
 		ports.ports = append(ports.ports, networking.NetworkPolicyPort{
-			Protocol: pointerTo(protocol),
+			Protocol: common.PointerTo(protocol),
 			Port:     portPointer,
 			EndPort:  endPortPointer})
 	}
@@ -100,7 +97,7 @@ func (ports *k8sAdminNetworkPorts) addPorts(start, end int64, protocols []core.P
 		if end == start {
 			//nolint:gosec // port should fit int32:
 			ports.ports = append(ports.ports, admin.AdminNetworkPolicyPort{
-				PortNumber: pointerTo(admin.Port{
+				PortNumber: common.PointerTo(admin.Port{
 					Protocol: protocol,
 					Port:     int32(start),
 				}),
@@ -108,7 +105,7 @@ func (ports *k8sAdminNetworkPorts) addPorts(start, end int64, protocols []core.P
 		} else {
 			ports.ports = append(ports.ports, admin.AdminNetworkPolicyPort{
 				//nolint:gosec // port should fit int32:
-				PortRange: pointerTo(admin.PortRange{
+				PortRange: common.PointerTo(admin.PortRange{
 					Protocol: protocol,
 					Start:    int32(start),
 					End:      int32(end),

--- a/pkg/synthesis/k8sPorts.go
+++ b/pkg/synthesis/k8sPorts.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/np-guard/models/pkg/netp"
 	"github.com/np-guard/models/pkg/netset"
-	"github.com/np-guard/vmware-analyzer/pkg/common"
 )
 
 func connToPolicyPort(conn *netset.TransportSet) []networking.NetworkPolicyPort {
@@ -81,7 +80,7 @@ func (ports *k8sNetworkPorts) addPorts(start, end int64, protocols []core.Protoc
 	}
 	for _, protocol := range protocols {
 		ports.ports = append(ports.ports, networking.NetworkPolicyPort{
-			Protocol: common.PointerTo(protocol),
+			Protocol: &protocol,
 			Port:     portPointer,
 			EndPort:  endPortPointer})
 	}
@@ -97,7 +96,7 @@ func (ports *k8sAdminNetworkPorts) addPorts(start, end int64, protocols []core.P
 		if end == start {
 			//nolint:gosec // port should fit int32:
 			ports.ports = append(ports.ports, admin.AdminNetworkPolicyPort{
-				PortNumber: common.PointerTo(admin.Port{
+				PortNumber: &(admin.Port{
 					Protocol: protocol,
 					Port:     int32(start),
 				}),
@@ -105,7 +104,7 @@ func (ports *k8sAdminNetworkPorts) addPorts(start, end int64, protocols []core.P
 		} else {
 			ports.ports = append(ports.ports, admin.AdminNetworkPolicyPort{
 				//nolint:gosec // port should fit int32:
-				PortRange: common.PointerTo(admin.PortRange{
+				PortRange: &(admin.PortRange{
 					Protocol: protocol,
 					Start:    int32(start),
 					End:      int32(end),

--- a/pkg/synthesis/synthesis_test.go
+++ b/pkg/synthesis/synthesis_test.go
@@ -236,10 +236,8 @@ func addDebugFiles(t *testing.T, rc *collector.ResourcesContainerModel, abstract
 
 	// the validation of the abstract model conversion is here:
 	// validate connectivity analysis is the same for the new (from abstract) and original NSX configs
-	// commenting the following out, since we do not suppoert creating nsx services:
-	// todo - uncomment when supporting services
-	// require.Equal(t, connectivity["txt"], analyzed,
-	// 	fmt.Sprintf("nsx and vmware connectivities of test %v are not equal", t.Name()))
+	require.Equal(t, connectivity["txt"], analyzed,
+		fmt.Sprintf("nsx and vmware connectivities of test %v are not equal", t.Name()))
 
 	// run netpol-analyzer
 	// todo - compare the k8s_connectivity.txt with vmware_connectivity.txt (currently they are not in the same format)


### PR DESCRIPTION
Description: 
In conversion to abstract model (produced by synthesis), validation then translates this model back to nsx config, and compares analyzed connectivity on original config vs converted config.
This PR should support custom connections in abstract model rules, to be converted as nsx service entries in this validation.