### PR TITLE
Tmp fix for ip6 addresses + fix not k8s legal labels 

### DIFF
--- a/pkg/configuration/topology.go
+++ b/pkg/configuration/topology.go
@@ -129,7 +129,7 @@ func (p *nsxConfigParser) getRuleBlocksVMs() {
 		// iterate over VMs, look if the vm address is in the block:
 		for _, vm := range p.configRes.VMs {
 			for _, address := range vm.(*topology.VM).IPAddresses() {
-				address, err := IPBlockFromIPAddress(address)
+				address, err := iIPBlockFromIPAddress(address)
 				if err != nil {
 					logging.Warnf("Could not resolve address %s of vm %s", address, vm.Name())
 					continue
@@ -157,10 +157,10 @@ func (p *nsxConfigParser) getRuleBlocksVMs() {
 }
 
 // tmp function till netset is fixed:
-func IPBlockFromIPAddress(ipAddress string) (*netset.IPBlock, error) {
+func iIPBlockFromIPAddress(ipAddress string) (*netset.IPBlock, error) {
 	startIP := net.ParseIP(ipAddress)
 	if startIP == nil || startIP.To4() == nil {
-		return nil, fmt.Errorf("%v is not a valid ipv4", ipAddress)
+		return nil, fmt.Errorf("%s is not a valid IPv4 address", ipAddress)
 	}
 	return netset.IPBlockFromIPAddress(ipAddress)
 }

--- a/pkg/configuration/topology.go
+++ b/pkg/configuration/topology.go
@@ -159,7 +159,7 @@ func (p *nsxConfigParser) getRuleBlocksVMs() {
 // tmp function till netset is fixed:
 func IPBlockFromIPAddress(ipAddress string) (*netset.IPBlock, error) {
 	startIP := net.ParseIP(ipAddress)
-	if startIP == nil || startIP.To4() == nil{
+	if startIP == nil || startIP.To4() == nil {
 		return nil, fmt.Errorf("%v is not a valid ipv4", ipAddress)
 	}
 	return netset.IPBlockFromIPAddress(ipAddress)

--- a/pkg/configuration/topology.go
+++ b/pkg/configuration/topology.go
@@ -1,7 +1,9 @@
 package configuration
 
 import (
+	"fmt"
 	"maps"
+	"net"
 	"slices"
 
 	"github.com/np-guard/models/pkg/netset"
@@ -127,7 +129,7 @@ func (p *nsxConfigParser) getRuleBlocksVMs() {
 		// iterate over VMs, look if the vm address is in the block:
 		for _, vm := range p.configRes.VMs {
 			for _, address := range vm.(*topology.VM).IPAddresses() {
-				address, err := netset.IPBlockFromIPAddress(address)
+				address, err := IPBlockFromIPAddress(address)
 				if err != nil {
 					logging.Warnf("Could not resolve address %s of vm %s", address, vm.Name())
 					continue
@@ -152,4 +154,13 @@ func (p *nsxConfigParser) getRuleBlocksVMs() {
 	for _, vm := range p.configRes.VMs {
 		p.ruleBlockPerEP[vm] = common.SliceCompact(p.ruleBlockPerEP[vm])
 	}
+}
+
+// tmp function till netset is fixed:
+func IPBlockFromIPAddress(ipAddress string) (*netset.IPBlock, error) {
+	startIP := net.ParseIP(ipAddress)
+	if startIP == nil || startIP.To4() == nil{
+		return nil, fmt.Errorf("%v is not a valid ipv4", ipAddress)
+	}
+	return netset.IPBlockFromIPAddress(ipAddress)
 }

--- a/pkg/synthesis/createK8sResources.go
+++ b/pkg/synthesis/createK8sResources.go
@@ -70,7 +70,7 @@ func (resources *k8sResources) createPods(model *AbstractModelSyn) {
 		pod := &core.Pod{}
 		pod.TypeMeta.Kind = "Pod"
 		pod.TypeMeta.APIVersion = "v1"
-		pod.ObjectMeta.Name = vm.Name()
+		pod.ObjectMeta.Name = toLegalK8SString(vm.Name())
 		pod.ObjectMeta.Namespace = core.NamespaceDefault
 		if len(model.epToGroups[vm]) == 0 {
 			continue

--- a/pkg/synthesis/createK8sResources.go
+++ b/pkg/synthesis/createK8sResources.go
@@ -79,10 +79,12 @@ func (resources *k8sResources) createPods(model *AbstractModelSyn) {
 		const theTrue = "true"
 		for _, group := range model.epToGroups[vm] {
 			label, _ := symbolicexpr.NewGroupAtomicTerm(group, false).AsSelector()
+			label = toLegalK8SString(label)
 			pod.ObjectMeta.Labels[label] = theTrue
 		}
 		for _, tag := range vm.Tags() {
 			label, _ := symbolicexpr.NewTagTerm(tag, false).AsSelector()
+			label = toLegalK8SString(label)
 			pod.ObjectMeta.Labels[label] = theTrue
 		}
 		resources.pods = append(resources.pods, pod)
@@ -124,5 +126,6 @@ func k8sAnalyzer(k8sDir, outfile, format string) (bool, error) {
 		return false, nil
 	}
 	cmd := exec.Command(analyzerExecPath, "list", "--dirpath", k8sDir, "--file", outfile, "--output", format)
+	logging.Debug(cmd.String())
 	return true, cmd.Run()
 }

--- a/pkg/synthesis/k8sPolicies.go
+++ b/pkg/synthesis/k8sPolicies.go
@@ -213,6 +213,11 @@ func toSelector(con symbolicexpr.Conjunction) *meta.LabelSelector {
 	return selector
 }
 
+// toLegalK8SString() replaces all the k8s illegal characters with "-NLC"
+// allowed characters are letters, numbers, '-', '.', '_'
+// this is a temp fix, still todo:
+// 1. two different illegal tags might create the same tag
+// 2. fix for pods names should be more restrict (only lower, no '_', ...)
 var reg = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
 
 func toLegalK8SString(s string) string {

--- a/pkg/synthesis/k8sPolicies.go
+++ b/pkg/synthesis/k8sPolicies.go
@@ -176,7 +176,7 @@ func newNetworkPolicy(name, description, nsxRuleID string) *networking.NetworkPo
 	pol := &networking.NetworkPolicy{}
 	pol.TypeMeta.Kind = "NetworkPolicy"
 	pol.TypeMeta.APIVersion = "networking.k8s.io/v1"
-	pol.ObjectMeta.Name = name
+	pol.ObjectMeta.Name = toLegalK8SString(name)
 	pol.ObjectMeta.Namespace = meta.NamespaceDefault
 	pol.ObjectMeta.Annotations = map[string]string{
 		annotationDescription: description,
@@ -189,7 +189,7 @@ func newAdminNetworkPolicy(name, description, nsxRuleID string) *admin.AdminNetw
 	pol := &admin.AdminNetworkPolicy{}
 	pol.TypeMeta.Kind = "AdminNetworkPolicy"
 	pol.TypeMeta.APIVersion = "policy.networking.k8s.io/v1alpha1"
-	pol.ObjectMeta.Name = name
+	pol.ObjectMeta.Name = toLegalK8SString(name)
 	pol.ObjectMeta.Annotations = map[string]string{
 		annotationDescription: description,
 		annotationUID:         nsxRuleID,

--- a/pkg/synthesis/k8sPolicies.go
+++ b/pkg/synthesis/k8sPolicies.go
@@ -213,7 +213,8 @@ func toSelector(con symbolicexpr.Conjunction) *meta.LabelSelector {
 	return selector
 }
 
+var reg = regexp.MustCompile(`[^-A-Za-z0-9_.]`)
+
 func toLegalK8SString(s string) string {
-	reg, _ := regexp.Compile(`[^-A-Za-z0-9_.]`)
 	return reg.ReplaceAllString(s, "-NLC")
 }

--- a/pkg/synthesis/k8sPolicies.go
+++ b/pkg/synthesis/k8sPolicies.go
@@ -3,6 +3,7 @@ package synthesis
 import (
 	"fmt"
 	"path"
+	"regexp"
 
 	networking "k8s.io/api/networking/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -204,9 +205,15 @@ func toSelector(con symbolicexpr.Conjunction) *meta.LabelSelector {
 	for _, a := range con {
 		if !a.IsTautology() {
 			label, notIn := a.AsSelector()
+			label = toLegalK8SString(label)
 			req := meta.LabelSelectorRequirement{Key: label, Operator: boolToOperator[notIn]}
 			selector.MatchExpressions = append(selector.MatchExpressions, req)
 		}
 	}
 	return selector
+}
+
+func toLegalK8SString(s string) string {
+	reg, _ := regexp.Compile(`[^-A-Za-z0-9_.]`)
+	return reg.ReplaceAllString(s, "-NLC")
 }


### PR DESCRIPTION
1. bug in netset panic on ipv6 addresses - I made a tmp fix and open issue on model repository
2. supporting not legal groups and tags names 